### PR TITLE
--strip

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,6 +85,7 @@ FLAGS:
     -h, --help               Prints help information
         --release            Pass --release to cargo
         --skip-auditwheel    Don't check for manylinux compliance
+        --strip              Strip the library for minimum file size
     -V, --version            Prints version information
 
 OPTIONS:
@@ -116,6 +117,7 @@ FLAGS:
     -h, --help               Prints help information
         --release            Pass --release to cargo
         --skip-auditwheel    Don't check for manylinux compliance
+        --strip              Strip the library for minimum file size
     -V, --version            Prints version information
 
 OPTIONS:
@@ -154,6 +156,7 @@ USAGE:
 FLAGS:
     -h, --help       Prints help information
         --release    Pass --release to cargo
+        --strip      Strip the library for minimum file size
     -V, --version    Prints version information
 
 OPTIONS:

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -56,6 +56,8 @@ pub struct BuildContext {
     pub out: PathBuf,
     /// Pass --release to cargo
     pub release: bool,
+    /// Strip the library for minimum file size
+    pub strip: bool,
     /// Don't check for manylinux compliance
     pub skip_auditwheel: bool,
     /// Extra arguments that will be passed to cargo as `cargo rustc [...] [arg1] [arg2] --`

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -42,6 +42,9 @@ pub struct BuildOptions {
     /// Pass --release to cargo
     #[structopt(long = "release")]
     pub release: bool,
+    /// Strip the library for minimum file size
+    #[structopt(long = "strip")]
+    pub strip: bool,
     /// Don't check for manylinux compliance
     #[structopt(long = "skip-auditwheel")]
     pub skip_auditwheel: bool,
@@ -64,6 +67,7 @@ impl Default for BuildOptions {
             manifest_path: PathBuf::from("Cargo.toml"),
             out: None,
             release: false,
+            strip: false,
             skip_auditwheel: false,
             target: None,
             cargo_extra_args: Vec::new(),
@@ -150,6 +154,7 @@ impl BuildOptions {
             manifest_path: self.manifest_path,
             out: wheel_dir,
             release: self.release,
+            strip: self.strip,
             skip_auditwheel: self.skip_auditwheel,
             cargo_extra_args,
             rustc_extra_args: self.rustc_extra_args,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -185,6 +185,10 @@ pub fn compile(
         }
     }
 
+    if context.strip {
+        rustc_args.extend(&["-C", "link-arg=-s"]);
+    }
+
     let build_args: Vec<_> = cargo_args
         .iter()
         .chain(&shared_args)

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -20,6 +20,7 @@ pub fn develop(
     rustc_extra_args: Vec<String>,
     venv_dir: &Path,
     release: bool,
+    strip: bool,
 ) -> Result<(), Error> {
     let target = Target::current();
 
@@ -37,6 +38,7 @@ pub fn develop(
         skip_auditwheel: true,
         target: None,
         release,
+        strip,
         cargo_extra_args,
         rustc_extra_args,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,9 @@ enum Opt {
         /// Pass --release to cargo
         #[structopt(long = "release")]
         release: bool,
+        /// Strip the library for minimum file size
+        #[structopt(long = "strip")]
+        strip: bool,
         /// Extra arguments that will be passed to cargo as `cargo rustc [...] [arg1] [arg2] --`
         #[structopt(long = "cargo-extra-args")]
         cargo_extra_args: Vec<String>,
@@ -264,6 +267,7 @@ fn run() -> Result<(), Error> {
             cargo_extra_args,
             rustc_extra_args,
             release,
+            strip,
         } => {
             let venv_dir = match env::var_os("VIRTUAL_ENV") {
                 Some(dir) => PathBuf::from(dir),
@@ -279,6 +283,7 @@ fn run() -> Result<(), Error> {
                 rustc_extra_args,
                 &venv_dir,
                 release,
+                strip,
             )?;
         }
     }

--- a/tests/test_develop.rs
+++ b/tests/test_develop.rs
@@ -58,7 +58,7 @@ fn test_develop(package: &Path, bindings: Option<String>) {
     }
 
     let manifest_file = package.join("Cargo.toml");
-    develop(bindings, &manifest_file, vec![], vec![], &venv_dir, false).unwrap();
+    develop(bindings, &manifest_file, vec![], vec![], &venv_dir, false, false).unwrap();
 
     check_installed(&package, &python).unwrap();
 }


### PR DESCRIPTION
This strips shared libraries through a link arg. It's a common enough case to merit its own flag, I think.