### PR TITLE
Look for `cpython` instead of `rust-cpython`

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -195,7 +195,7 @@ pub fn find_bridge(
     } else if deps.contains("pyo3") {
         println!("Found pyo3 bindings");
         Ok(BridgeModel::Bindings("pyo3".to_string()))
-    } else if deps.contains("rust-cpython") {
+    } else if deps.contains("cpython") {
         println!("Found rust-python bindings");
         Ok(BridgeModel::Bindings("rust_cpython".to_string()))
     } else {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -144,7 +144,9 @@ pub fn compile(
 
     let mut shared_args = vec!["--manifest-path", context.manifest_path.to_str().unwrap()];
 
-    if python_feature != "" {
+    if *bindings_crate == BridgeModel::Bindings("pyo3".to_string())
+        && python_feature != ""
+    {
         // This is a workaround for a bug in pyo3's build.rs
         shared_args.extend(&["--features", &python_feature]);
     }


### PR DESCRIPTION
This PR does two things:

- It looks for `cpython` as a depencency, since the crate is (renamed to?) [cpython](https://crates.io/crates/cpython).
- It only  passes `--features` flags to `pyo3`, since `rust-cpython`  does not recognize them.

Tested this on my `rust-cpython` package, and called `cargo test` in `pyo3-pack` with no errors.