### PR TITLE
Add support for conda envs on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ matrix:
   fast_finish: true
 
 install:
+  - cinst miniconda3
   - ps: |
       # For the gnu target we need gcc, provided by mingw. mingw which is already preinstalled,
       # but we need the right version (32-bit or 64-bit) to the PATH.

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -71,7 +71,7 @@ pub struct BuildContext {
 impl BuildContext {
     /// Checks which kind of bindings we have (pyo3/rust-cypthon or cffi or bin) and calls the
     /// correct builder. Returns a Vec that contains location, python tag (e.g. py2.py3 or cp35)
-    /// and for bindings the python intepreter they bind against.
+    /// and for bindings the python interpreter they bind against.
     pub fn build_wheels(&self) -> Result<Vec<(PathBuf, String, Option<PythonInterpreter>)>, Error> {
         fs::create_dir_all(&self.out)
             .context("Failed to create the target directory for the wheels")?;

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -100,8 +100,12 @@ fn find_all_windows(target: &Target) -> Result<Vec<String>, Error> {
                         .parse::<usize>()
                         .context(context)?;
 
-                    if windows_interpreter_no_build(major, minor, target.pointer_width(), pointer_width)
-                    {
+                    if windows_interpreter_no_build(
+                        major,
+                        minor,
+                        target.pointer_width(),
+                        pointer_width,
+                    ) {
                         continue;
                     }
 
@@ -128,8 +132,8 @@ fn find_all_windows(target: &Target) -> Result<Vec<String>, Error> {
         let lines = str::from_utf8(&output.stdout).unwrap().lines();
         let re = Regex::new(r"(\w|\\|:|-)+$").unwrap();
         let mut paths = vec![];
-        for i in lines.into_iter() {
-            if !i.starts_with("#") {
+        for i in lines {
+            if !i.starts_with('#') {
                 if let Some(capture) = re.captures(&i) {
                     paths.push(String::from(&capture[0]));
                 }
@@ -155,10 +159,14 @@ fn find_all_windows(target: &Target) -> Result<Vec<String>, Error> {
                         32_usize
                     };
 
-                    if windows_interpreter_no_build(major, minor, target.pointer_width(), pointer_width)
-                        {
-                            continue;
-                        }
+                    if windows_interpreter_no_build(
+                        major,
+                        minor,
+                        target.pointer_width(),
+                        pointer_width,
+                    ) {
+                        continue;
+                    }
 
                     interpreter.push(executable);
                     versions_found.insert((major, minor));

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -173,7 +173,7 @@ fn find_all_windows(target: &Target) -> Result<Vec<String>, Error> {
         }
 
         for path in paths {
-            let executable = format!(r"{}\python", path);
+            let executable = Path::new(&path).join("python");
             let python_info = Command::new(&executable)
                 .arg("-c")
                 .arg("import sys; print(sys.version)")
@@ -200,7 +200,7 @@ fn find_all_windows(target: &Target) -> Result<Vec<String>, Error> {
                         continue;
                     }
 
-                    interpreter.push(executable);
+                    interpreter.push(String::from(executable.to_str().unwrap()));
                     versions_found.insert((major, minor));
                 }
             }

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -59,12 +59,44 @@ fn windows_interpreter_no_build(
     false
 }
 
-/// Uses `py -0` to get a list of all installed python versions and then
-/// `sys.executable` to determine the path.
+/// On windows regular Python installs are supported along with environments
+/// being managed by `conda`.
 ///
-/// We can't use the the linux trick with trying different binary names since
-/// on windows the binary is always called "python.exe". We also have to make
-/// sure that the pointer width (32-bit or 64-bit) matches across platforms
+/// We can't use the linux trick with trying different binary names since on
+/// windows the binary is always called "python.exe".  However, whether dealing
+/// with regular Python installs or `conda` environments there are tools we can
+/// use to query the information regarding installed interpreters.
+///
+/// Regular Python installs downloaded from Python.org will include the python
+/// launcher by default.  We can use the launcher to find the information we need
+/// for each installed interpreter using `py -0` which produces something like
+/// the following output (the path can by determined using `sys.executable`):
+///
+/// ```bash
+/// Installed Pythons found by py Launcher for Windows
+/// -3.7-64 *
+/// -3.6-32
+/// -2.7-64
+/// ```
+///
+/// When using `conda` we can use the `conda info -e` command to retrieve information
+/// regarding the installed interpreters being managed by `conda`.  This is an example
+/// of the output expected:
+///
+/// ```bash
+/// # conda environments:
+/// #
+/// base                     C:\Users\<user-name>\Anaconda3
+/// foo1                  *  C:\Users\<user-name>\Anaconda3\envs\foo1
+/// foo2                  *  C:\Users\<user-name>\Anaconda3\envs\foo2
+/// ```
+///
+/// The information required can either by obtained by parsing this output directly or
+/// by invoking the interpreters to obtain the information.
+///
+/// As well as the version numbers, etc. of the interpreters we also have to find the
+/// pointer width to make sure that the pointer width (32-bit or 64-bit) matches across
+/// platforms.
 fn find_all_windows(target: &Target) -> Result<Vec<String>, Error> {
     let code = "import sys; print(sys.executable or '')";
     let mut interpreter = vec![];

--- a/tests/test_integration.rs
+++ b/tests/test_integration.rs
@@ -141,6 +141,7 @@ fn test_integration(package: &Path, bindings: Option<String>) {
     }
 }
 
+/// Creates conda environments
 fn create_conda_env(name: &str, major: usize, minor: usize) {
     Command::new("conda")
         .arg("create")

--- a/tests/test_integration.rs
+++ b/tests/test_integration.rs
@@ -157,11 +157,12 @@ fn create_conda_env(name: &str, major: usize, minor: usize) {
 fn test_integration_conda(package: &Path, bindings: Option<String>) {
     let package_string = package.join("Cargo.toml").display().to_string();
 
-    // Create environments to build against
-    create_conda_env("pyo3-build-env-27", 2, 7);
-    create_conda_env("pyo3-build-env-35", 3, 5);
-    create_conda_env("pyo3-build-env-36", 3, 6);
-    create_conda_env("pyo3-build-env-37", 3, 7);
+    // Create environments to build against, prepended with "A" to ensure that integration
+    // tests are executed with these environments
+    create_conda_env("A-pyo3-build-env-27", 2, 7);
+    create_conda_env("A-pyo3-build-env-35", 3, 5);
+    create_conda_env("A-pyo3-build-env-36", 3, 6);
+    create_conda_env("A-pyo3-build-env-37", 3, 7);
 
     // The first string is ignored by clap
     let cli = if let Some(ref bindings) = bindings {
@@ -184,25 +185,36 @@ fn test_integration_conda(package: &Path, bindings: Option<String>) {
         .build_wheels()
         .unwrap();
 
+    let mut conda_wheels: Vec<(PathBuf, PathBuf)> = vec![];
     for (filename, _, python_interpreter) in wheels {
         if let Some(pi) = python_interpreter {
             let executable = pi.executable;
-
-            let output = Command::new(&executable)
-                .args(&[
-                    "-m",
-                    "pip",
-                    "install",
-                    "--force-reinstall",
-                    &adjust_canonicalization(filename),
-                ])
-                .stderr(Stdio::inherit())
-                .output()
-                .unwrap();
-            if !output.status.success() {
-                panic!();
+            if executable.to_str().unwrap().contains("pyo3-build-env-") {
+                conda_wheels.push((filename, executable))
             }
-            check_installed(&package, &executable).unwrap();
         }
+    }
+
+    assert_eq!(
+        4,
+        conda_wheels.len(),
+        "Error creating or detecting conda environments."
+    );
+    for (wheel_file, executable) in conda_wheels {
+        let output = Command::new(&executable)
+            .args(&[
+                "-m",
+                "pip",
+                "install",
+                "--force-reinstall",
+                &adjust_canonicalization(wheel_file),
+            ])
+            .stderr(Stdio::inherit())
+            .output()
+            .unwrap();
+        if !output.status.success() {
+            panic!();
+        }
+        check_installed(&package, &executable).unwrap();
     }
 }


### PR DESCRIPTION
Hey @konstin,

I have support for building with `conda` on windows working.  I just tested this locally by running `pyo3-pack build` for the `get_fourtytwo` example.

I'm assuming that supporting `conda` on other systems would be pretty much the same but I'm not able to test this.

I'll take a look at updating CI to test this in another PR.