### PR TITLE
Warn about missing PyInit function to fix #124

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ regex = "1.1.6"
 indicatif = "0.11.0"
 atty = "0.2.11"
 tempfile = "3.0.7"
-goblin = { version = "0.0.22", optional = true }
+goblin = "0.0.22"
 pretty_env_logger = { version = "0.3.0", optional = true }
 platforms = "0.2.0"
 shlex = "0.1.1"
@@ -52,7 +52,7 @@ indoc = "0.3.3"
 
 [features]
 default = ["auditwheel", "log", "upload", "rustls"]
-auditwheel = ["goblin"]
+auditwheel = []
 upload = ["reqwest", "rpassword"]
 password-storage = ["upload", "keyring"]
 log = ["pretty_env_logger"]

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -65,7 +65,7 @@ pub fn develop(
             fs::copy(artifact, bin_path)?;
         }
         BridgeModel::Cffi => {
-            let artifact = build_context.compile_cdylib(None).context(context)?;
+            let artifact = build_context.compile_cdylib(None, None).context(context)?;
 
             write_cffi_module(
                 &mut builder,
@@ -77,7 +77,7 @@ pub fn develop(
         }
         BridgeModel::Bindings(_) => {
             let artifact = build_context
-                .compile_cdylib(Some(&interpreter))
+                .compile_cdylib(Some(&interpreter), Some(&build_context.module_name))
                 .context(context)?;
 
             write_bindings_module(


### PR DESCRIPTION
Example output:

```
🔗 Found pyo3 bindings
🐍 Found CPython 3.6m at python3.6
⚠  Warning: Couldn't find the symbol `PyInit_get_fourtytwo` in the native library. Python will fail to import this module. If you're using pyo3, check that `#[pymodule]` uses `get_fourtytwo` as module name
📦 Built wheel for CPython 3.6m to /home/konsti/pyo3-pack/get-fourtytwo/target/wheels/get_fourtytwo-2.1.0-cp36-cp36m-manylinux1_x86_64.whl
```