### PR TITLE
Error messages for bad cargo/rust environment during PEP517 install

### DIFF
--- a/pyo3_pack/__init__.py
+++ b/pyo3_pack/__init__.py
@@ -100,6 +100,16 @@ def get_requires_for_build_sdist(config_settings=None):
 
 # noinspection PyUnusedLocal
 def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    print("Checking for Rust toolchain....")
+    output = subprocess.check_output(["cargo", "--version"]).decode("utf-8", "ignore")
+    if not "cargo" in output:
+        sys.stderr.write(
+            "cargo, the Rust language build tool, is not installed or is not on PATH.\n"
+            "This package requires Rust to compile extensions. Install it through\n"
+            "the system's package manager or via https://rustup.rs/\n"
+        )
+        sys.exit(1)
+
     command = [
         "pyo3-pack",
         "pep517",


### PR DESCRIPTION
The error output from pip is otherwise not understandable by
a user who does not know this package needs Rust or what Rust is.

  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... error
    ERROR: Complete output from command ... pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel ...
    ERROR: 💥 pyo3-pack failed
    Cargo metadata failed: No such file or directory (os error 2)
    ...
    subprocess.CalledProcessError: Command '['pyo3-pack', 'pep517', 'write-dist-info', ... ' returned non-zero exit status 1

#2 