### PR TITLE
 Support building projects for FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,9 @@
 freebsd_instance:
   image: freebsd-12-0-release-amd64
 
+env:
+  RUST_BACKTRACE: 1
+
 freebsd_task:
   name: $TOOLCHAIN x86_64-unknown-freebsd
   env:
@@ -12,3 +15,5 @@ freebsd_task:
     - sh rustup.sh -y --default-toolchain $TOOLCHAIN
   build_script:
     - $HOME/.cargo/bin/rustup run $TOOLCHAIN cargo build
+  test_script:
+    - $HOME/.cargo/bin/rustup run $TOOLCHAIN cargo test --features skip-nightly-tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,15 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "platform-info"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "platforms"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1136,7 @@ dependencies = [
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indoc 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "keyring 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "platform-info 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "platforms 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2257,6 +2267,7 @@ dependencies = [
 "checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+"checksum platform-info 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f2fd076acdc7a98374de6e300bf3af675997225bef21aecac2219553f04dd7e8"
 "checksum platforms 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cfec0daac55b13af394ceaaad095d17c790f77bdc9329264f06e49d6cd3206c"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ cbindgen = { version = "0.9.0", default-features = false }
 walkdir = "2.2.8"
 flate2 = "1.0.9"
 tar = "0.4.26"
+platform-info = "0.0.1"
 
 [dev-dependencies]
 indoc = "0.3.3"

--- a/src/get_interpreter_metadata.py
+++ b/src/get_interpreter_metadata.py
@@ -14,7 +14,7 @@ metadata = {
     "u": sysconfig.get_config_var("Py_UNICODE_SIZE") == 4,
     "d": sysconfig.get_config_var("Py_DEBUG") == 1,
     # This one isn't technically necessary, but still very useful for sanity checks
-    "platform": sys.platform,
+    "platform": platform.system().lower(),
 }
 
 print(json.dumps(metadata))

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -277,8 +277,8 @@ pub struct PythonInterpreter {
     ///
     /// See PEP 261 and PEP 393 for details
     pub abiflags: String,
-    /// Currently just the value of [Target::os()], i.e. "windows", "linux" or
-    /// "macos"
+    /// Currently just the value of [Target::os()], i.e. "windows", "linux",
+    /// "macos" or "freebsd"
     pub target: Target,
     /// Path to the python interpreter, e.g. /usr/bin/python3.6
     ///
@@ -308,6 +308,7 @@ fn fun_with_abiflags(
         "win32" | "win_amd64" => target.is_windows(),
         "linux" | "linux2" | "linux3" => target.is_linux(),
         "darwin" => target.is_macos(),
+        "freebsd11" | "freebsd12" | "freebsd13" => target.is_freebsd(),
         _ => false,
     };
 
@@ -420,6 +421,7 @@ impl PythonInterpreter {
     /// Linux:   steinlaus.cpython-35m-x86_64-linux-gnu.so
     /// Windows: steinlaus.cp35-win_amd64.pyd
     /// Mac:     steinlaus.cpython-35m-darwin.so
+    /// FreeBSD: steinlaus.cpython-35m.so
     ///
     /// For pypy3, we read sysconfig.get_config_var("EXT_SUFFIX").
     ///
@@ -430,7 +432,15 @@ impl PythonInterpreter {
             Interpreter::CPython => {
                 let platform = self.target.get_shared_platform_tag();
 
-                if self.target.is_unix() {
+                if self.target.is_freebsd() {
+                    format!(
+                        "{base}.cpython-{major}{minor}{abiflags}.so",
+                        base = base,
+                        major = self.major,
+                        minor = self.minor,
+                        abiflags = self.abiflags,
+                    )
+                } else if self.target.is_unix() {
                     format!(
                         "{base}.cpython-{major}{minor}{abiflags}-{platform}.so",
                         base = base,

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -305,10 +305,10 @@ fn fun_with_abiflags(
     target: &Target,
 ) -> Result<String, Error> {
     let sane_platform = match message.platform.as_ref() {
-        "win32" | "win_amd64" => target.is_windows(),
-        "linux" | "linux2" | "linux3" => target.is_linux(),
+        "windows" => target.is_windows(),
+        "linux" => target.is_linux(),
         "darwin" => target.is_macos(),
-        "freebsd11" | "freebsd12" | "freebsd13" => target.is_freebsd(),
+        "freebsd" => target.is_freebsd(),
         _ => false,
     };
 


### PR DESCRIPTION
This adds basic FreeBSD support. Basic, because it works for my few
cases. There are two major differences from how things works for Linux
and rest platforms:

The first is  that there is no custom suffix for produced `.so` files
and `imp.get_suffixes()` confirms that.

The second is more complicated. There is no universal platform tag which
covers some OS release. In fact, it includes information about:
- OS version (11_2, 12_0),
- release type (RELEASE, STABLE)
- and patch set (p1, p7, etc).

While first two are pretty well known and could be simply hardcoded
to maintain support for a many years, patch set is very generic and
changes once any security or system fixes get issued for specific
release. From point of FreeBSD it's the same system with the same
compatibility guarantees. From point of Python it's a completely
different platform which is not compatible with the others patches
for the same OS version and release.

That means that wheels need to be rebuild (or just renamed) if system
receives any patch set update.